### PR TITLE
Analyze repository contents

### DIFF
--- a/connect_signalr.js
+++ b/connect_signalr.js
@@ -4,14 +4,22 @@ export function establishWebSocketConnection(websocketUrl, playId, playerName) {
     const ws = new WebSocket(websocketUrl);
 
     ws.on('open', () => {
+        console.log('🔗 WebSocket connection opened');
         const handshake = { protocol: "json", version: 1 };
         ws.send(JSON.stringify(handshake) + '\u001e');
     });
 
     ws.on('message', (message) => {
+        // Log ALL messages to catch medal/results events
+        console.log(`📨 RAW MESSAGE: ${message.toString()}`);
+        
         const parsedMessage = JSON.parse(message.toString().replace('\u001e', ''));
+        
+        // Log parsed message structure
+        console.log(`📋 PARSED MESSAGE:`, JSON.stringify(parsedMessage, null, 2));
 
         if (message.toString() === "{}\u001e") {
+            console.log('🤝 Sending PlayerJoined message');
             const playerJoined = {
                 type: 1,
                 target: "PlayerJoined",
@@ -21,6 +29,7 @@ export function establishWebSocketConnection(websocketUrl, playId, playerName) {
         }
 
         if (parsedMessage.type === 1 && parsedMessage.target === "ShowQuestion") {
+            console.log('❓ Question received, processing...');
             const questionData = parsedMessage.arguments[0];
             const rightAnswer = questionData.rightAnswer;
             const maxAnswers = questionData.maxAnswers;
@@ -36,6 +45,7 @@ export function establishWebSocketConnection(websocketUrl, playId, playerName) {
             const mappedAnswer = answerMapping[rightAnswer];
 
             if (mappedAnswer !== undefined) {
+                console.log(`✅ Sending answer: ${mappedAnswer}`);
                 const answerMessage = {
                     type: 1,
                     target: "AnswerGivenFromPlayer",
@@ -45,11 +55,39 @@ export function establishWebSocketConnection(websocketUrl, playId, playerName) {
             }
         }
 
+        // Check for potential medal/results events
+        if (parsedMessage.type === 1) {
+            const target = parsedMessage.target;
+            
+            // Look for potential medal/results related events
+            if (target && (
+                target.includes('Result') || 
+                target.includes('Medal') || 
+                target.includes('Achievement') || 
+                target.includes('Award') || 
+                target.includes('Score') || 
+                target.includes('End') || 
+                target.includes('Finish') || 
+                target.includes('Complete') ||
+                target.includes('Summary') ||
+                target.includes('Stats')
+            )) {
+                console.log(`🏅 POTENTIAL MEDAL/RESULTS EVENT: ${target}`);
+                console.log(`🏅 ARGUMENTS:`, JSON.stringify(parsedMessage.arguments, null, 2));
+            }
+        }
+
         if (parsedMessage.type === 1 && parsedMessage.target === "PlayerDisconnected" && parsedMessage.arguments[0] === true) {
+            console.log('👋 Player disconnected');
             ws.close();
         }
     });
 
-    ws.on('error', () => {});
-    ws.on('close', () => {});
+    ws.on('error', (error) => {
+        console.error('❌ WebSocket error:', error);
+    });
+    
+    ws.on('close', () => {
+        console.log('🔌 WebSocket connection closed');
+    });
 }

--- a/server.js
+++ b/server.js
@@ -103,7 +103,13 @@ async function createEnhancedWebSocketConnection(websocketUrl, playId, playerNam
         connectionData.lastActivity = Date.now();
         
         try {
+            // Log ALL messages to catch medal/results events
+            console.log(`📨 [${playerName}] RAW MESSAGE: ${message.toString()}`);
+            
             const parsedMessage = JSON.parse(message.toString().replace('\u001e', ''));
+            
+            // Log parsed message structure
+            console.log(`📋 [${playerName}] PARSED MESSAGE:`, JSON.stringify(parsedMessage, null, 2));
 
             if (message.toString() === "{}\u001e") {
                 const playerJoined = {
@@ -112,7 +118,7 @@ async function createEnhancedWebSocketConnection(websocketUrl, playId, playerNam
                     arguments: [playId, playerName]
                 };
                 ws.send(JSON.stringify(playerJoined) + '\u001e');
-                console.log(`Player ${playerName} joined game ${playId}`);
+                console.log(`🤝 Player ${playerName} joined game ${playId}`);
             }
 
             if (parsedMessage.type === 1 && parsedMessage.target === "ShowQuestion") {
@@ -120,7 +126,7 @@ async function createEnhancedWebSocketConnection(websocketUrl, playId, playerNam
                 const rightAnswer = questionData.rightAnswer;
                 const maxAnswers = questionData.maxAnswers;
 
-                console.log(`Question received for ${playerName}, answering...`);
+                console.log(`❓ Question received for ${playerName}, answering...`);
 
                 const answerMapping = {};
                 for (let i = 0; i < maxAnswers; i++) {
@@ -140,17 +146,47 @@ async function createEnhancedWebSocketConnection(websocketUrl, playId, playerNam
                     };
                     ws.send(JSON.stringify(answerMessage) + '\u001e');
                     connectionData.questionsAnswered++;
-                    console.log(`Answer sent for ${playerName}: ${mappedAnswer} (Total: ${connectionData.questionsAnswered})`);
+                    console.log(`✅ Answer sent for ${playerName}: ${mappedAnswer} (Total: ${connectionData.questionsAnswered})`);
+                }
+            }
+
+            // Check for potential medal/results events
+            if (parsedMessage.type === 1) {
+                const target = parsedMessage.target;
+                
+                // Look for potential medal/results related events
+                if (target && (
+                    target.includes('Result') || 
+                    target.includes('Medal') || 
+                    target.includes('Achievement') || 
+                    target.includes('Award') || 
+                    target.includes('Score') || 
+                    target.includes('End') || 
+                    target.includes('Finish') || 
+                    target.includes('Complete') ||
+                    target.includes('Summary') ||
+                    target.includes('Stats') ||
+                    target.includes('Leaderboard') ||
+                    target.includes('Ranking')
+                )) {
+                    console.log(`🏅 [${playerName}] POTENTIAL MEDAL/RESULTS EVENT: ${target}`);
+                    console.log(`🏅 [${playerName}] ARGUMENTS:`, JSON.stringify(parsedMessage.arguments, null, 2));
+                }
+                
+                // Log ALL events we haven't seen before
+                if (target !== "ShowQuestion" && target !== "PlayerDisconnected") {
+                    console.log(`🔍 [${playerName}] UNKNOWN EVENT: ${target}`);
+                    console.log(`🔍 [${playerName}] ARGUMENTS:`, JSON.stringify(parsedMessage.arguments, null, 2));
                 }
             }
 
             if (parsedMessage.type === 1 && parsedMessage.target === "PlayerDisconnected" && parsedMessage.arguments[0] === true) {
-                console.log(`Player ${playerName} disconnected from game`);
+                console.log(`👋 Player ${playerName} disconnected from game`);
                 connectionData.connected = false;
                 ws.close();
             }
         } catch (error) {
-            console.error('Message parsing error:', error);
+            console.error('❌ Message parsing error:', error);
         }
     });
 


### PR DESCRIPTION
Add comprehensive SignalR message logging to identify and capture medal/results events.

The bot was previously only handling `ShowQuestion`, `PlayerDisconnected`, and `PlayerJoined` events. This change introduces detailed logging of all incoming SignalR messages, including raw and parsed formats, to help identify the specific events that contain medal and game result information, which are displayed in the Panquiz results tab.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6625206-98e3-4f23-ac58-a4d58bab317e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6625206-98e3-4f23-ac58-a4d58bab317e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>